### PR TITLE
adjust submodule URI locator to succeed without key auth

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = git://anongit.freedesktop.org/gstreamer/common
 [submodule "gst-libs/ext/droidmedia"]
 	path = gst-libs/ext/droidmedia
-	url = git@github.com:sailfishos/droidmedia.git
+	url = https://github.com/sailfishos/droidmedia.git


### PR DESCRIPTION
Otherwise it errors out as:
Cloning into 'gst-libs/ext/droidmedia'...
Permission denied (publickey).
fatal: Could not read from remote repository.
